### PR TITLE
chore(cla): allowlist maintainer nqzai

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -29,7 +29,7 @@ jobs:
           path-to-signatures: 'signatures/version1/cla.json'
           path-to-document: 'https://github.com/nqzai/kakunin-sdk-typescript/blob/main/CLA.md'
           branch: 'main'
-          allowlist: 'dependabot[bot],*[bot],renovate[bot]'
+          allowlist: 'nqzai,dependabot[bot],*[bot],renovate[bot]'
           custom-notsigned-prcomment: >
             Thank you for your contribution! Before we can merge, please read and
             sign the [Kakunin Contributor License Agreement](https://github.com/nqzai/kakunin-sdk-typescript/blob/main/CLA.md)


### PR DESCRIPTION
Exempt the repo owner (`nqzai`) from the CLA gate. Activating the CLA otherwise blocks the maintainer's own PRs — every committer is required to sign. External contributors still sign. Matches the fix already applied to kakunin-core / -mcp / -integrations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)