### PR TITLE
Document and test CommonJS usage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,5 +32,8 @@ jobs:
       - name: Build
         run: npm run build
 
+      - name: CommonJS smoke test
+        run: npm run test:cjs
+
       - name: Test
         run: npm test

--- a/README.md
+++ b/README.md
@@ -40,6 +40,17 @@ const verified = await kkn.verify.cert(cert.serial_number);
 console.log(verified.status); // "active" | "revoked" | "expired"
 ```
 
+### CommonJS
+
+The CommonJS build exposes the same API through `require`:
+
+```javascript
+const { Kakunin } = require('@kakunin/sdk');
+
+const kkn = new Kakunin({ apiKey: process.env.KAKUNIN_API_KEY });
+console.log(kkn.isSandbox());
+```
+
 ## Sandbox mode
 
 Use a `kak_test_...` key to hit the sandbox CA at no cost. Certificates are real X.509 but issued by a test root and have no regulatory validity.

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   ],
   "scripts": {
     "build": "tsup src/index.ts src/verify/index.ts src/verify/supabase.ts --format cjs,esm --dts --clean",
+    "test:cjs": "node tests/cjs-smoke.cjs",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/tests/cjs-smoke.cjs
+++ b/tests/cjs-smoke.cjs
@@ -1,0 +1,6 @@
+const { Kakunin } = require('../dist/index.js');
+
+const client = new Kakunin({ apiKey: 'kak_test_commonjs' });
+if (!client.isSandbox()) {
+  throw new Error('CommonJS Kakunin export did not initialize correctly');
+}


### PR DESCRIPTION
Fixes #12.

Document CommonJS usage and add a built-package `require` smoke test to CI.

Validation: clean install, production audit, type-check, CJS/ESM build, CommonJS smoke test, and 42 tests passed.
