### PR TITLE
ci: bump scorecard-action to v2.4.4 (gcr.io -> ghcr.io)

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -26,7 +26,7 @@ jobs:
           persist-credentials: false
 
       - name: "Run analysis"
-        uses: ossf/scorecard-action@62b2cac7ed8198b15735ed49ab1e5cf35480ba46 # v2.4.0
+        uses: ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc # v2.4.4
         with:
           results_file: results.sarif
           results_format: sarif


### PR DESCRIPTION
## What
Bumps `ossf/scorecard-action` from v2.4.0 to v2.4.4.

## Why
The weekly Scorecard run has failed since 2026-09-07. It never reaches the analysis — it dies pulling the action's container image:

```
Error response from daemon: Head "https://gcr.io/v2/openssf/scorecard-action/manifests/v2.4.0":
denied: This API method requires billing to be enabled.
```

Google retired `gcr.io`, and the billing project named in that error belongs to **OpenSSF, not us** — there is nothing to enable on our side. OpenSSF republished the image on GitHub Container Registry.

v2.4.0 is the last release pointing at the dead registry:

| tag | image |
|---|---|
| v2.4.0 | `gcr.io/openssf/scorecard-action` |
| v2.4.1 – v2.4.4 | `ghcr.io/ossf/scorecard-action` |

So any version ≥ v2.4.1 fixes it. Going to v2.4.4 (current latest, Scorecard v5.5.0) rather than the minimum bump.

## Changes
- `.github/workflows/scorecard.yml` — one line, the `uses:` pin.

SHA `2d1146689b8cda280b9bc96326124645441f03bc` is the tag-dereferenced **commit** for v2.4.4, keeping the repo's SHA-pinning convention intact.

## Risk
Low. One-line workflow change, no source or dependency impact. Worst case the run keeps failing and we are no worse off; the analysis has already been dark for a week. Same change is going to all five repos that run Scorecard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
